### PR TITLE
Fix absolute pattern handling

### DIFF
--- a/lib/find/finder.go
+++ b/lib/find/finder.go
@@ -9,7 +9,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 type Finder interface {
@@ -47,8 +46,10 @@ func (f *finder) Run(ctx context.Context, paths []string) ([]FileInfo, error) {
 		}
 
 		var formattedPattern string
-		if strings.Split(pattern, "")[0] == string(os.PathSeparator) {
-			formattedPattern = strings.Join(strings.Split(pattern, "")[1:], "")
+		if pattern[0] == os.PathSeparator {
+			formattedPattern = pattern[1:]
+		} else {
+			formattedPattern = pattern
 		}
 
 		// TODO(sundowndev): run this in a goroutine?


### PR DESCRIPTION
## Summary
- avoid splitting pattern strings when checking for absolute paths
- keep or trim leading path separator accordingly

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685bd6170884832a8d212fe8b049d79c

## Summary by Sourcery

Correct the logic for formatting search patterns by detecting and trimming leading path separators directly rather than splitting the string.

Bug Fixes:
- Fix absolute pattern handling by checking the first byte of the pattern instead of using string splits and trimming the leading path separator correctly.

Enhancements:
- Remove the unnecessary strings import and simplify pattern formatting logic.