### PR TITLE
Add context-aware analysis

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"github.com/schollz/progressbar/v3"
 	"github.com/sirupsen/logrus"
@@ -52,7 +53,7 @@ covermyass --write -z -n 5
 			}
 
 			analyzer := analysis.NewAnalyzer(filterEngine)
-			a, err := analyzer.Analyze()
+			a, err := analyzer.Analyze(context.Background())
 			if err != nil {
 				return err
 			}

--- a/lib/analysis/analyzer.go
+++ b/lib/analysis/analyzer.go
@@ -24,7 +24,7 @@ func NewAnalyzer(filterEngine filter.Filter) *Analyzer {
 	}
 }
 
-func (a *Analyzer) Analyze() (*Analysis, error) {
+func (a *Analyzer) Analyze(ctx context.Context) (*Analysis, error) {
 	analysis := NewAnalysis()
 
 	output.Printf("Loaded known log files for %s\n", runtime.GOOS)
@@ -35,7 +35,7 @@ func (a *Analyzer) Analyze() (*Analysis, error) {
 	for _, c := range check.GetAllChecks() {
 		wg.Add(1)
 		go func(c check.Check) {
-			results, err := a.finder.Run(context.TODO(), c.Paths())
+			results, err := a.finder.Run(ctx, c.Paths())
 			if err != nil {
 				logrus.Error(err)
 				return


### PR DESCRIPTION
## Summary
- pass `context.Context` into Analyzer.Analyze
- propagate the context from `root` command

## Testing
- `go test ./...` *(fails: connection to proxy.golang.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685bd6198b8c832ab4fa7ba0c5ad5f29

## Summary by Sourcery

Add context support to Analyzer.Analyze and propagate context from the root command

Enhancements:
- Update Analyzer.Analyze to accept a context.Context parameter
- Pass the provided context through to finder.Run instead of using context.TODO()
- Propagate context.Background from the root command into Analyzer.Analyze