### PR TITLE
Add Codex setup script

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Update package list and install build tools
+apt-get update
+apt-get install -y --no-install-recommends git make curl ca-certificates golang-go
+
+# Install Go tools required by the Makefile
+export PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
+
+# Install test and lint dependencies
+go install gotest.tools/gotestsum@v1.6.3
+
+go install github.com/vektra/mockery/v2@v2.16.0
+
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
+

--- a/.codex/tests.sh
+++ b/.codex/tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Run unit tests with coverage
+make test


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` to install Go and tooling
- add `.codex/tests.sh` to execute tests

## Testing
- `./.codex/tests.sh` *(fails: gotestsum: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685be8ac1c80832a9420a6e9716bc0ce

## Summary by Sourcery

Add Codex setup and test scripts to streamline Go environment provisioning and test execution

New Features:
- Add `.codex/setup.sh` to automate Go environment and tooling installation

Tests:
- Add `.codex/tests.sh` to execute unit tests via `make test`